### PR TITLE
fix: incorrect token in auto-approve settings

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: hmarr/auto-approve-action@v2.2.1
         with:
-          github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -9,7 +9,7 @@ const project = new GitHubActionTypeScriptProject({
   name: 'github-merit-badger',
   autoApproveOptions: {
     allowedUsernames: ['cdklabs-automation'],
-    secret: 'PROJEN_GITHUB_TOKEN',
+    secret: 'GITHUB_TOKEN',
   },
   autoApproveUpgrades: true,
   actionMetadata: {


### PR DESCRIPTION
We use the cdklabs bot to create the post so the github-actions bot has to be the one to actually approve. Using the default token achieves that.